### PR TITLE
Use Twitch’s V5 API when getting user’s information

### DIFF
--- a/lib/ueberauth/strategy/twitchtv.ex
+++ b/lib/ueberauth/strategy/twitchtv.ex
@@ -176,11 +176,14 @@ defmodule Ueberauth.Strategy.TwitchTv do
   Stores the raw information (including the token) obtained from the Twitch Tv callback.
   """
   def extra(conn) do
+    user = conn.private.twitch_tv_user
+
     %Extra {
       raw_info: %{
         token: conn.private.twitch_tv_token,
-        user: conn.private.twitch_tv_user,
-        is_partnered: conn.private.twitch_tv_user["partnered"]
+        user: user,
+        is_partnered: user["partnered"],
+        email_verified: user["email_verified"]
       }
     }
   end
@@ -188,7 +191,7 @@ defmodule Ueberauth.Strategy.TwitchTv do
   defp fetch_user(conn, token) do
     conn = put_private(conn, :twitch_tv_token, token)
     path = "https://api.twitch.tv/kraken/user"
-    headers = [Authorization: "OAuth #{token.access_token}"]
+    headers = [Authorization: "OAuth #{token.access_token}", Accept: "application/vnd.twitchtv.v5+json"]
     resp = OAuth2.AccessToken.get(token, path, headers)
 
     case resp do


### PR DESCRIPTION
By adding the `Accept: application/vnd.twitchtv.v5+json` header when fetching the user's data, it will now hit Twitch's V5 API which provides a bit more informaton. In my case, `email_verified` is what I'm looking for. I've also added that field to the `raw_info` for easier accessibility.

One breaking change with this is that in a developer's `AuthController` module to handle Ueberauth authentications, `auth.extra.raw_info.user["_id"]` is now a binary instead of an integer since the V5 API returns `_id` as a string instead of an integer like in the V3 API.